### PR TITLE
Override getConfigFile() method for Windows

### DIFF
--- a/src/main/java/aQute/jpm/platform/Windows.java
+++ b/src/main/java/aQute/jpm/platform/Windows.java
@@ -72,7 +72,7 @@ public class Windows extends Platform {
 	 */
 	@Override
 	public File getLocal() {
-		return IO.getFile("~/.jpm/windows");
+		return IO.getFile(System.getProperty("user.home") + "/.jpm/windows");
 	}
 
 	/**

--- a/src/main/java/aQute/jpm/platform/Windows.java
+++ b/src/main/java/aQute/jpm/platform/Windows.java
@@ -181,6 +181,11 @@ public class Windows extends Platform {
 	}
 
 	@Override
+	public String getConfigFile() throws Exception {
+		return System.getProperty("user.home") + "/.jpm/settings.json";
+	}
+
+	@Override
 	public void deleteCommand(CommandData cmd) throws Exception {
 		String executable = getExecutable(cmd);
 		File f = new File(executable);


### PR DESCRIPTION
Hi @gamerson 

This pr is related to https://issues.liferay.com/browse/LPP-36730.

I found there are some problems caused by getting wrong location of "settings.json" file.
 
1.  we get this file by [getConfigFile() method](https://github.com/bndtools/jpmcli/blob/7b9eca82b9e6e0a5cd540e4e30d1835876a51b58/src/main/java/aQute/jpm/platform/Platform.java#L224) method 
`
	public String getConfigFile() throws Exception {
		return "~/.jpm/settings.json";
	} `
2.  when the file path startwith "\~/" , the IO.getFile(File base, String file) method will transfer "\~" to home parameter.

		
	public static File getFile(File base, String file) {

		if (file.startsWith("\~/")) {

			file = file.substring(2);

			if (!file.startsWith("\~/")) {
				return getFile(home, file);
			}

		}

		if (file.startsWith("~")) {
			file = file.substring(1);
			return getFile(home.getParentFile(), file);
		}

		File f = new File(file);

		if (f.isAbsolute())
			return f;
		if (base == null)
			base = work;

		f = base.getAbsoluteFile();

		for (int n; (n = file.indexOf('/')) > 0;) {
			String first = file.substring(0, n);
			file = file.substring(n + 1);
			if (first.equals(".."))
				f = f.getParentFile();
			else
				f = new File(f, first);
		}
		if (file.equals(".."))
			return f.getParentFile();
		return new File(f, file).getAbsoluteFile();
	}

3.  The value of home parameter will be initialized statically.

static final public File		home;

	static {
		File tmp = null;
		try {
			tmp = new File(System.getenv("HOME"));
		} catch (Exception e) {}
		if (tmp == null) {
			tmp = new File(System.getProperty("user.home"));
		}
		home = tmp;
	}

For Linux and Mac, the HOME env always has a default value (like user profile), but for Windows, this environtment variable needs user to set it. (HOME can point to a network share, while the user profile is always local).

So I overrided the getConfigFile() method for Windows by using user home rather than "~".

